### PR TITLE
Add Docker and compose support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Stage 1: build the app
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Stage 2: production image
+FROM node:20-alpine
+ENV NODE_ENV=production
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY --from=builder /app/dist ./dist
+EXPOSE 5000
+CMD ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Dhaka Food Cart - Khawa Dawa
+
+This project can be run locally using Docker. The repository provides a
+`Dockerfile` and a `docker-compose.yml` that set up the application and a
+PostgreSQL database.
+
+## Running with Docker Compose
+
+1. Copy `.env.example` to `.env` and adjust values for your environment.
+   The `DATABASE_URL` should point to the `db` service as shown below.
+
+   ```env
+   DATABASE_URL=postgresql://postgres:U6w$UE_X-F$B7hC@db:5432/postgres
+   ```
+
+2. Build and start the containers:
+
+   ```bash
+   docker-compose up --build
+   ```
+
+The web service will be available at `http://localhost:5000`.
+
+### Environment variables
+
+Place your `.env` file in the repository root. The compose file loads this
+file automatically and passes the variables to the `web` container. Refer to
+`.env.example` for the list of variables that can be configured.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+services:
+  web:
+    build: .
+    ports:
+      - "5000:5000"
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: postgresql://postgres:U6w$UE_X-F$B7hC@db:5432/postgres
+    depends_on:
+      - db
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: U6w$UE_X-F$B7hC
+      POSTGRES_DB: postgres
+    volumes:
+      - db_data:/var/lib/postgresql/data
+volumes:
+  db_data:


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile for building and running the app
- add docker-compose.yml with web and database services
- document Docker usage in README

## Testing
- `npm run check`
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aeb92ed18832c95833505616e6dbe